### PR TITLE
Fix detection of fail2ban-server process

### DIFF
--- a/plugins/check_fail2ban
+++ b/plugins/check_fail2ban
@@ -92,7 +92,7 @@ if [ ! "$MANUAL" = true ]; then
 fi
 
 # check for running service
-ps -aux | grep "/usr/bin/fail2ban-server" | grep -v grep > /dev/null 2>&1
+COLUMNS="" ps -aux | grep "/usr/bin/fail2ban-server" | grep -v grep > /dev/null 2>&1
 if [[ "$?" == "0" ]]; then
     echo "OK: fail2ban running"
 else


### PR DESCRIPTION
We discovered a corner case where icinga on an old system (debian jessie) is started with COLUMNS=100 in its environment. This cuts off the output of the `ps -aux` command used for testing if fail2ban-server is running, rendering the detection useless. The server process is always reported as not running, even if it is running. Simply setting COLUMNS to an empty value prevents this bug, which may be triggered otherwise, too.